### PR TITLE
proprietary-files: Use stock liboemcrypto so we can get L1

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -73,8 +73,10 @@ lib/libnvtnr.so
 lib/libnvtvmr.so
 lib/libnvwinsys.so
 lib/libnvwsi.so
+lib/liboemcrypto.so
 lib/libremotecontrolservice.so
 lib/libstagefrighthw.so
+lib/libstlport.so
 lib/libtf_crypto_sst.so
 lib/libtsechdcp.so
 lib/libtsec_wrapper.so

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -142,3 +142,6 @@
 
 # drm
 /data/DxDrm(/.*)?                                   u:object_r:drm_data_file:s0
+
+# tee
+/data/tf(/.*)?                                      u:object_r:tee_data_file:s0

--- a/sepolicy/tee.te
+++ b/sepolicy/tee.te
@@ -1,0 +1,2 @@
+allow tee tee_data_file:dir ra_dir_perms;
+allow tee tee_data_file:file create_file_perms;


### PR DESCRIPTION
This allows Netflix to work, but requires libstlport :/
Add sepolicy for tf_daemon